### PR TITLE
[Tokenizer.cs] String.Equals instead of String.Compare gives 3x speedup

### DIFF
--- a/yaza/Tokenizer.cs
+++ b/yaza/Tokenizer.cs
@@ -95,7 +95,7 @@ namespace yaza
 
         public bool IsIdentifier(string str)
         {
-            return _token == Token.Identifier && string.Compare(str, _string, true) == 0;
+            return _token == Token.Identifier && string.Equals(str, _string, StringComparison.OrdinalIgnoreCase);
         }
 
         public bool TrySkipIdentifier(string str)


### PR DESCRIPTION
For assembling my .ASM file which has 170,000 lines, this change gives about a factor of 3 speedup.

**Before**

<pre>
Errors: 0 Warnings: 0   12,195,732
Errors: 0 Warnings: 0   10,116,247
Errors: 0 Warnings: 0   11,213,140
</pre>

**After**

<pre>
Errors: 0 Warnings: 0    4,273,499
Errors: 0 Warnings: 0    4,097,903
Errors: 0 Warnings: 0    4,001,640
</pre>
